### PR TITLE
fix: use ptr when using loop variable in publisher

### DIFF
--- a/gosqs/publisher.go
+++ b/gosqs/publisher.go
@@ -67,7 +67,7 @@ func (p *SQSPublisher) sendBatch(msgs []sendRequest) ([]results.Result[string], 
 		id := strconv.Itoa(i)
 		entry := types.SendMessageBatchRequestEntry{
 			Id:           &id,
-			MessageBody:  &msg.body,
+			MessageBody:  ptr(msg.body),
 			DelaySeconds: int32(msg.delaySeconds),
 		}
 		entries = append(entries, entry)


### PR DESCRIPTION
```
    for i, msg := range msgs {
        // TODO: better to use a GUID?
        id := strconv.Itoa(i)
        entry := types.SendMessageBatchRequestEntry{
            Id:           &id,
            MessageBody:  &msg.body,
            DelaySeconds: int32(msg.delaySeconds),
        }
        entries = append(entries, entry)
        keyMap[id] = i
    }
```
In the code for `sendBatch`, the reused loop variable `msg` gets the source copied into it during each iteration. So when we create `entry`, `MessageBody` is set to a pointer for the reused loops variable's `body`, instead of a pointer to the source (`&msgs[i].body`) 
 